### PR TITLE
Added ability to fix "only"

### DIFF
--- a/rules/no-only-test.js
+++ b/rules/no-only-test.js
@@ -9,7 +9,25 @@ module.exports = function (context) {
 			if (tape.isTestFile && tape.currentTestNode === node && tape.hasTestModifier('only')) {
 				context.report({
 					node: node,
-					message: '`test.only()` should not be used.'
+					message: '`test.only()` should not be used.',
+					fix(fixer) {
+						const {callee} = node;
+						 
+						if (callee.type !== 'MemberExpression')
+							return;
+				  
+						const {
+							object,
+							property,
+						} = callee;
+						
+						if (property.type !== 'Identifier')
+							return;
+					
+						return [
+							fixer.replaceTextRange([callee.start, callee.end], object.name),
+						];
+					},
 				});
 			}
 		}


### PR DESCRIPTION
With this addition you can fix `test.only() should not be used` error with:

```
eslint test --fix
```
So code:

```js
test.only('some test case', (t) => {
    t.end();
});
```

Becames:

```js
test('some test case', (t) => {
    t.end();
});
```