### PR TITLE
feat: support the tape.teardown() method

### DIFF
--- a/rules/use-t-well.js
+++ b/rules/use-t-well.js
@@ -6,6 +6,7 @@ var tapeAssertionMethods = require('../tape-assertion-methods');
 var methods = [
 	'end',
 	'plan',
+	'teardown',
 	'test'
 ].concat(Object.keys(tapeAssertionMethods));
 


### PR DESCRIPTION
This was landed in v5.2.0 – see https://github.com/substack/tape/pull/546